### PR TITLE
Add private endpoints reonciler Service

### DIFF
--- a/pkg/privateendpoints/scope_test.go
+++ b/pkg/privateendpoints/scope_test.go
@@ -16,7 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/giantswarm/azure-private-endpoint-operator/pkg/azure"
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/azure/mock_azure"
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/errors"
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/privateendpoints"
@@ -29,7 +28,6 @@ const (
 )
 
 var _ = Describe("Scope", func() {
-	var err error
 	var subscriptionID string
 	var resourceGroup string
 	var gomockController *gomock.Controller
@@ -42,7 +40,6 @@ var _ = Describe("Scope", func() {
 		subscriptionID = "1234"
 		resourceGroup = "test-rg"
 		gomockController = gomock.NewController(GinkgoT())
-		err = nil
 		privateEndpointNames = []string{
 			"test-private-endpoint-0",
 			"test-private-endpoint-1",
@@ -54,7 +51,6 @@ var _ = Describe("Scope", func() {
 	Describe("creating scope", func() {
 		var azureCluster *capz.AzureCluster
 		var client client.Client
-		var privateEndpointClient azure.PrivateEndpointsClient
 
 		BeforeEach(func() {
 			azureCluster = testhelpers.NewAzureClusterBuilder(subscriptionID, resourceGroup).
@@ -69,33 +65,35 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("creates scope", func(ctx context.Context) {
+			var err error
 			scope, err = privateendpoints.NewScope(ctx, azureCluster, client, privateEndpointClient)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(scope).NotTo(BeNil())
 		})
 
 		It("fails to create scope when AzureCluster is nil", func(ctx context.Context) {
-			azureCluster = nil
-			scope, err = privateendpoints.NewScope(ctx, azureCluster, client, privateEndpointClient)
+			var err error
+			scope, err = privateendpoints.NewScope(ctx, nil, client, privateEndpointClient)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsInvalidConfig(err)).To(BeTrue())
 		})
 
 		It("fails to create scope when Kubernetes client is nil", func(ctx context.Context) {
-			client = nil
-			scope, err = privateendpoints.NewScope(ctx, azureCluster, client, privateEndpointClient)
+			var err error
+			scope, err = privateendpoints.NewScope(ctx, azureCluster, nil, privateEndpointClient)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsInvalidConfig(err)).To(BeTrue())
 		})
 
 		It("fails to create scope when Azure private endpoints client is nil", func(ctx context.Context) {
-			privateEndpointClient = nil
-			scope, err = privateendpoints.NewScope(ctx, azureCluster, client, privateEndpointClient)
+			var err error
+			scope, err = privateendpoints.NewScope(ctx, azureCluster, client, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsInvalidConfig(err)).To(BeTrue())
 		})
 
 		It("fails to create scope when AzureCluster does not have subnets", func(ctx context.Context) {
+			var err error
 			azureCluster.Spec.NetworkSpec.Subnets = capz.Subnets{}
 			scope, err = privateendpoints.NewScope(ctx, azureCluster, client, privateEndpointClient)
 			Expect(err).To(HaveOccurred())

--- a/pkg/privateendpoints/service.go
+++ b/pkg/privateendpoints/service.go
@@ -1,0 +1,158 @@
+package privateendpoints
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/apimachinery/pkg/types"
+	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api-provider-azure/util/slice"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/giantswarm/azure-private-endpoint-operator/pkg/errors"
+)
+
+// PrivateLinksScope is the interface for getting private links for which the private endpoints are needed.
+type PrivateLinksScope interface {
+	GetClusterName() types.NamespacedName
+	GetSubscriptionID() string
+	GetLocation() string
+	GetResourceGroup() string
+	GetPrivateLinksWithAllowedSubscription(managementClusterSubscriptionID string) []capz.PrivateLink
+	LookupPrivateLink(privateLinkResourceID string) (capz.PrivateLink, bool)
+	PatchObject(ctx context.Context) error
+	PrivateLinksReady() bool
+	SetPrivateEndpointIPAddress(ip net.IP)
+	Close(ctx context.Context) error
+}
+
+type Service struct {
+	privateEndpointsScope Scope
+	privateLinksScope     PrivateLinksScope
+}
+
+func NewService(privateEndpointsScope Scope, privateLinksScope PrivateLinksScope) (*Service, error) {
+	if privateEndpointsScope == nil {
+		return nil, microerror.Maskf(errors.InvalidConfigError, "privateEndpointsScope must be set")
+	}
+	if privateLinksScope == nil {
+		return nil, microerror.Maskf(errors.InvalidConfigError, "privateLinksScope must be set")
+	}
+
+	return &Service{
+		privateEndpointsScope: privateEndpointsScope,
+		privateLinksScope:     privateLinksScope,
+	}, nil
+}
+
+func (s *Service) Reconcile(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	//
+	// First get all workload cluster private links. We will create private endpoints for all of
+	// them (by default there will be only one).
+	//
+	privateLinks := s.privateLinksScope.GetPrivateLinksWithAllowedSubscription(s.privateEndpointsScope.GetSubscriptionID())
+	if len(privateLinks) == 0 {
+		return microerror.Maskf(
+			errors.SubscriptionCannotConnectToPrivateLinkError,
+			"MC %s Azure subscription %s is not allowed to connect to any private link from the private workload cluster %s",
+			s.privateEndpointsScope.GetClusterName(),
+			s.privateEndpointsScope.GetSubscriptionID(),
+			s.privateLinksScope.GetClusterName())
+	}
+
+	if len(privateLinks) > 0 && !s.privateLinksScope.PrivateLinksReady() {
+		errorMessage := "Workload cluster private links are not yet ready"
+		logger.Info(errorMessage)
+		return microerror.Maskf(errors.PrivateLinksNotReadyError, errorMessage)
+	}
+
+	//
+	// Add new private endpoints
+	//
+	for _, privateLink := range privateLinks {
+		logger.Info(fmt.Sprintf("Found private link %s", privateLink.Name))
+		manualApproval := !slice.Contains(privateLink.AutoApprovedSubscriptions, s.privateEndpointsScope.GetSubscriptionID())
+		var requestMessage string
+		if manualApproval {
+			requestMessage = fmt.Sprintf("Giant Swarm azure-private-endpoint-operator that is running in "+
+				"management cluster %s created private endpoint in order to access private workload cluster %s",
+				s.privateEndpointsScope.GetClusterName().Name,
+				s.privateLinksScope.GetClusterName().Name)
+		}
+
+		wantedPrivateEndpoint := capz.PrivateEndpointSpec{
+			Name:     fmt.Sprintf("%s-privateendpoint", privateLink.Name),
+			Location: s.privateEndpointsScope.GetLocation(),
+			PrivateLinkServiceConnections: []capz.PrivateLinkServiceConnection{
+				{
+					Name: fmt.Sprintf("%s-connection", privateLink.Name),
+					PrivateLinkServiceID: fmt.Sprintf(
+						"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateLinkServices/%s",
+						s.privateLinksScope.GetSubscriptionID(),
+						s.privateLinksScope.GetResourceGroup(),
+						privateLink.Name),
+					RequestMessage: requestMessage,
+				},
+			},
+			ManualApproval: manualApproval,
+		}
+		s.privateEndpointsScope.AddPrivateEndpointSpec(wantedPrivateEndpoint)
+		logger.Info(fmt.Sprintf("Ensured private endpoint %s is added to %s", wantedPrivateEndpoint.Name, s.privateEndpointsScope.GetClusterName()))
+
+		// Apps running in the MC access WC API server via private endpoint that connects to private
+		// link. For that access MC apps are connecting to the private endpoint IP from the MC
+		// subnet. Here we set that private endpoint IP in the workload AzureCluster as an
+		// annotation. dns-operator-azure will then use that annotation to create A records in the
+		// DNS zone in the MC resource group, so that MC apps can access WC API server via FQDN.
+		privateEndpointIPAddress, err := s.privateEndpointsScope.GetPrivateEndpointIPAddress(ctx, wantedPrivateEndpoint.Name)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		logger.Info("found private endpoint IP address in MC", "ipAddress", privateEndpointIPAddress.String())
+		s.privateLinksScope.SetPrivateEndpointIPAddress(privateEndpointIPAddress)
+		logger.Info("set private endpoint IP address in WC AzureCluster", "ipAddress", privateEndpointIPAddress.String())
+	}
+
+	//
+	// Remove unused private endpoints that are connecting to the deleted private links.
+	// We are not deleting private links from running workload clusters, nor we planned to do so, but implementing this
+	// for the sake of the implementation being more future-proof.
+	//
+	privateEndpointsToWorkloadCluster := s.privateEndpointsScope.GetPrivateEndpointsToWorkloadCluster(
+		s.privateLinksScope.GetSubscriptionID(),
+		s.privateLinksScope.GetResourceGroup())
+	for _, privateEndpoint := range privateEndpointsToWorkloadCluster {
+		privateEndpointIsUsed := false
+		// check all private link connections in the private endpoint (we create just one, there shouldn't be more, but
+		// here we check the whole slice just in case)
+		for _, privateLinkConnection := range privateEndpoint.PrivateLinkServiceConnections {
+			_, foundPrivateLinkForTheConnection := s.privateLinksScope.LookupPrivateLink(privateLinkConnection.PrivateLinkServiceID)
+			if foundPrivateLinkForTheConnection {
+				privateEndpointIsUsed = true
+			}
+		}
+		if !privateEndpointIsUsed {
+			s.privateEndpointsScope.RemovePrivateEndpointByName(privateEndpoint.Name)
+			logger.Info(fmt.Sprintf("Removed private endpoint %s that is not used", privateEndpoint.Name))
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) Delete(_ context.Context) error {
+	// First get all workload cluster private links. We will delete private endpoints for all of
+	// them.
+	privateLinks := s.privateLinksScope.GetPrivateLinksWithAllowedSubscription(s.privateEndpointsScope.GetSubscriptionID())
+
+	// For every private link, delete its corresponding private endpoint.
+	for _, privateLink := range privateLinks {
+		privateEndpointName := fmt.Sprintf("%s-privateendpoint", privateLink.Name)
+		s.privateEndpointsScope.RemovePrivateEndpointByName(privateEndpointName)
+	}
+
+	return nil
+}

--- a/pkg/privateendpoints/service_test.go
+++ b/pkg/privateendpoints/service_test.go
@@ -1,0 +1,41 @@
+package privateendpoints_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/giantswarm/azure-private-endpoint-operator/pkg/errors"
+	"github.com/giantswarm/azure-private-endpoint-operator/pkg/privateendpoints"
+)
+
+var _ = Describe("Service", func() {
+	var err error
+	var privateLinksScope privateendpoints.PrivateLinksScope
+	var privateEndpointsScope privateendpoints.Scope
+	var service privateendpoints.Service
+
+	When("workload cluster has a private link", func() {
+		It("successfully reconciles by creating a private endpoint for the private link", func(ctx context.Context) {
+			err = service.Reconcile(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	When("there is no private link where MC subscription is allowed", func() {
+		It("returns SubscriptionCannotConnectToPrivateLink error", func(ctx context.Context) {
+			err = service.Reconcile(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsSubscriptionCannotConnectToPrivateLinkError(err)).To(BeTrue())
+		})
+	})
+
+	When("there workload cluster private links are not ready", func() {
+		It("returns SubscriptionCannotConnectToPrivateLink error", func(ctx context.Context) {
+			err = service.Reconcile(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsPrivateLinksNotReady(err)).To(BeTrue())
+		})
+	})
+})

--- a/pkg/privateendpoints/service_test.go
+++ b/pkg/privateendpoints/service_test.go
@@ -193,7 +193,7 @@ var _ = Describe("Service", func() {
 				mcResourceGroup,
 				expectedPrivateEndpointName)
 
-			expectedPrivateEndpoint := expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, expectedPrivateEndpointName, testPrivateLinkName)
+			expectedPrivateEndpoint := expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, testPrivateLinkName)
 
 			// private endpoint does not exist yet
 			exists := privateEndpointsScope.ContainsPrivateEndpointSpec(expectedPrivateEndpoint)
@@ -224,7 +224,7 @@ var _ = Describe("Service", func() {
 				expectedPrivateEndpointName,
 				expectedPrivateEndpointIp)
 
-			expectedPrivateEndpoint := expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, expectedPrivateEndpointName, testPrivateLinkName)
+			expectedPrivateEndpoint := expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, testPrivateLinkName)
 
 			// private endpoint does not exist yet
 			exists := privateEndpointsScope.ContainsPrivateEndpointSpec(expectedPrivateEndpoint)
@@ -249,7 +249,7 @@ var _ = Describe("Service", func() {
 		BeforeEach(func(ctx context.Context) {
 			// MC AzureCluster resource with private endpoints, as the WC has already been reconciled
 			expectedPrivateEndpointName := fmt.Sprintf("%s-privateendpoint", testPrivateLinkName)
-			privateEndpoints := capz.PrivateEndpoints{expectedPrivateEndpointSpec(location, subscriptionID, mcResourceGroup, expectedPrivateEndpointName, testPrivateLinkName)}
+			privateEndpoints := capz.PrivateEndpoints{expectedPrivateEndpointSpec(location, subscriptionID, mcResourceGroup, testPrivateLinkName)}
 			managementAzureCluster = testhelpers.NewAzureClusterBuilder(subscriptionID, mcResourceGroup).
 				WithLocation(location).
 				WithSubnet("test-subnet", capz.SubnetNode, privateEndpoints).
@@ -294,8 +294,7 @@ var _ = Describe("Service", func() {
 		})
 
 		It("reconciles in an idempotent way, so new private endpoint is not added", func(ctx context.Context) {
-			expectedPrivateEndpointName := fmt.Sprintf("%s-privateendpoint", testPrivateLinkName)
-			expectedPrivateEndpoint := expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, expectedPrivateEndpointName, testPrivateLinkName)
+			expectedPrivateEndpoint := expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, testPrivateLinkName)
 
 			// private endpoint already exists
 			exists := privateEndpointsScope.ContainsPrivateEndpointSpec(expectedPrivateEndpoint)
@@ -325,8 +324,8 @@ var _ = Describe("Service", func() {
 			expectedPrivateEndpointName := fmt.Sprintf("%s-privateendpoint", testPrivateLinkName)
 			removedPrivateLinkName = "another-private-link"
 			privateEndpoints := capz.PrivateEndpoints{
-				expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, expectedPrivateEndpointName, testPrivateLinkName),
-				expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, expectedPrivateEndpointName, removedPrivateLinkName),
+				expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, testPrivateLinkName),
+				expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, removedPrivateLinkName),
 			}
 			managementAzureCluster = testhelpers.NewAzureClusterBuilder(subscriptionID, mcResourceGroup).
 				WithLocation(location).
@@ -372,8 +371,8 @@ var _ = Describe("Service", func() {
 		})
 
 		It("removes corresponding private endpoint from the management cluster", func(ctx context.Context) {
-			removedPrivateEndpoint := expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, "", removedPrivateLinkName)
-			presentPrivateEndpoint := expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, "", testPrivateLinkName)
+			removedPrivateEndpoint := expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, removedPrivateLinkName)
+			presentPrivateEndpoint := expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, testPrivateLinkName)
 
 			// there are two private endpoints in the MC AzureCluster
 			Expect(managementAzureCluster.Spec.NetworkSpec.Subnets[0].PrivateEndpoints).To(HaveLen(2))
@@ -404,7 +403,7 @@ var _ = Describe("Service", func() {
 	When("workload cluster has been deleted", func() {
 		BeforeEach(func(ctx context.Context) {
 			// MC AzureCluster resource with private endpoints, as the WC has already been reconciled
-			privateEndpoints := capz.PrivateEndpoints{expectedPrivateEndpointSpec(location, subscriptionID, mcResourceGroup, "", testPrivateLinkName)}
+			privateEndpoints := capz.PrivateEndpoints{expectedPrivateEndpointSpec(location, subscriptionID, mcResourceGroup, testPrivateLinkName)}
 			managementAzureCluster = testhelpers.NewAzureClusterBuilder(subscriptionID, mcResourceGroup).
 				WithLocation(location).
 				WithSubnet("test-subnet", capz.SubnetNode, privateEndpoints).
@@ -444,7 +443,7 @@ var _ = Describe("Service", func() {
 		})
 
 		It("removes private endpoint from the management cluster", func(ctx context.Context) {
-			removedPrivateEndpoint := expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, "", testPrivateLinkName)
+			removedPrivateEndpoint := expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, testPrivateLinkName)
 
 			// initially there is one private endpoint in the MC AzureCluster
 			Expect(managementAzureCluster.Spec.NetworkSpec.Subnets[0].PrivateEndpoints).To(HaveLen(1))
@@ -467,7 +466,7 @@ var _ = Describe("Service", func() {
 	})
 })
 
-func expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, expectedPrivateEndpointName, privateLinkName string) capz.PrivateEndpointSpec {
+func expectedPrivateEndpointSpec(location, subscriptionID, wcResourceGroup, privateLinkName string) capz.PrivateEndpointSpec {
 	privateEndpointSpec := testhelpers.NewPrivateEndpointBuilder(fmt.Sprintf("%s-privateendpoint", privateLinkName)).
 		WithLocation(location).
 		WithPrivateLinkServiceConnection(subscriptionID, wcResourceGroup, privateLinkName).

--- a/pkg/privateendpoints/service_test.go
+++ b/pkg/privateendpoints/service_test.go
@@ -2,40 +2,163 @@ package privateendpoints_test
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/giantswarm/azure-private-endpoint-operator/pkg/errors"
+	"github.com/giantswarm/azure-private-endpoint-operator/pkg/azure/mock_azure"
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/privateendpoints"
+	"github.com/giantswarm/azure-private-endpoint-operator/pkg/privatelinks"
+	"github.com/giantswarm/azure-private-endpoint-operator/pkg/testhelpers"
+)
+
+const (
+	testPrivateLinkName = "test-private-link"
 )
 
 var _ = Describe("Service", func() {
 	var err error
+	var subscriptionID string
+	var location string
+	var resourceGroup string
+	var managementAzureCluster *capz.AzureCluster
+	var workloadAzureCluster *capz.AzureCluster
 	var privateLinksScope privateendpoints.PrivateLinksScope
 	var privateEndpointsScope privateendpoints.Scope
-	var service privateendpoints.Service
+	var service *privateendpoints.Service
 
-	When("workload cluster has a private link", func() {
-		It("successfully reconciles by creating a private endpoint for the private link", func(ctx context.Context) {
-			err = service.Reconcile(ctx)
+	BeforeEach(func() {
+		subscriptionID = "1234"
+		location = "westeurope"
+		resourceGroup = "test-rg"
+	})
+
+	When("workload cluster with private link has just been created and private links are ready", func() {
+		// This the scenario where we have a newly created workload AzureCluster. Here management
+		// AzureCluster still does not have corresponding private endpoint, and we test that it
+		// will be created successfully.
+
+		BeforeEach(func(ctx context.Context) {
+			// MC AzureCluster resource (without private endpoints, as the WC has just been created)
+			managementAzureCluster = testhelpers.NewAzureClusterBuilder(subscriptionID, resourceGroup).
+				WithLocation(location).
+				WithSubnet("test-subnet", capz.SubnetNode, nil).
+				Build()
+
+			// WC AzureClusterResource
+			workloadAzureCluster = testhelpers.NewAzureClusterBuilder(subscriptionID, resourceGroup).
+				WithPrivateLink(testhelpers.NewPrivateLinkBuilder(testPrivateLinkName).
+					WithAllowedSubscription(subscriptionID).
+					Build()).
+				WithCondition(conditions.TrueCondition(capz.PrivateLinksReadyCondition)).
+				Build()
+
+			// Kubernetes client
+			capzSchema, err := capz.SchemeBuilder.Build()
+			Expect(err).NotTo(HaveOccurred())
+			client := fake.NewClientBuilder().
+				WithScheme(capzSchema).
+				WithObjects(managementAzureCluster).Build()
+
+			// Azure private endpoints mock client
+			gomockController := gomock.NewController(GinkgoT())
+			privateEndpointClient := mock_azure.NewMockPrivateEndpointsClient(gomockController)
+			expectedPrivateEndpointName := fmt.Sprintf("%s-%s", testPrivateLinkName, "privateendpoint")
+			expectedPrivateIpString := "10.10.10.10"
+			privateEndpointClient.
+				EXPECT().
+				Get(
+					gomock.Any(),
+					gomock.Eq(resourceGroup),
+					gomock.Eq(expectedPrivateEndpointName),
+					gomock.Eq(&armnetwork.PrivateEndpointsClientGetOptions{
+						Expand: to.Ptr[string]("NetworkInterfaces"),
+					})).
+				Return(armnetwork.PrivateEndpointsClientGetResponse{
+					PrivateEndpoint: armnetwork.PrivateEndpoint{
+						Properties: &armnetwork.PrivateEndpointProperties{
+							NetworkInterfaces: []*armnetwork.Interface{
+								{
+									Properties: &armnetwork.InterfacePropertiesFormat{
+										IPConfigurations: []*armnetwork.InterfaceIPConfiguration{
+											{
+												Properties: &armnetwork.InterfaceIPConfigurationPropertiesFormat{
+													PrivateIPAddress: to.Ptr(expectedPrivateIpString),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}, nil)
+
+			// Private endpoints scope
+			privateEndpointsScope, err = privateendpoints.NewScope(ctx, managementAzureCluster, client, privateEndpointClient)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Private links scope
+			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Private endpoints service
+			service, err = privateendpoints.NewService(privateEndpointsScope, privateLinksScope)
 			Expect(err).NotTo(HaveOccurred())
 		})
-	})
 
-	When("there is no private link where MC subscription is allowed", func() {
-		It("returns SubscriptionCannotConnectToPrivateLink error", func(ctx context.Context) {
+		It("creates a new private endpoint for the private link", func(ctx context.Context) {
+			expectedPrivateEndpoint := capz.PrivateEndpointSpec{
+				Name:     fmt.Sprintf("%s-privateendpoint", testPrivateLinkName),
+				Location: location,
+				PrivateLinkServiceConnections: []capz.PrivateLinkServiceConnection{
+					{
+						Name: fmt.Sprintf("%s-connection", testPrivateLinkName),
+						PrivateLinkServiceID: fmt.Sprintf(
+							"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateLinkServices/%s",
+							subscriptionID,
+							resourceGroup,
+							testPrivateLinkName),
+						RequestMessage: "",
+					},
+				},
+				ManualApproval: false,
+			}
+
+			// private endpoint does not exist yet
+			exists := privateEndpointsScope.ContainsPrivateEndpointSpec(expectedPrivateEndpoint)
+			Expect(exists).To(BeFalse())
+
+			// Reconcile newly created workload cluster
 			err = service.Reconcile(ctx)
-			Expect(err).To(HaveOccurred())
-			Expect(errors.IsSubscriptionCannotConnectToPrivateLinkError(err)).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+
+			// private endpoint now exists
+			exists = privateEndpointsScope.ContainsPrivateEndpointSpec(expectedPrivateEndpoint)
+			Expect(exists).To(BeTrue())
 		})
 	})
 
-	When("there workload cluster private links are not ready", func() {
-		It("returns SubscriptionCannotConnectToPrivateLink error", func(ctx context.Context) {
-			err = service.Reconcile(ctx)
-			Expect(err).To(HaveOccurred())
-			Expect(errors.IsPrivateLinksNotReady(err)).To(BeTrue())
-		})
-	})
+	//When("there is no private link where MC subscription is allowed", func() {
+	//	It("returns SubscriptionCannotConnectToPrivateLink error", func(ctx context.Context) {
+	//		err = service.Reconcile(ctx)
+	//		Expect(err).To(HaveOccurred())
+	//		Expect(errors.IsSubscriptionCannotConnectToPrivateLinkError(err)).To(BeTrue())
+	//	})
+	//})
+	//
+	//When("there workload cluster private links are not ready", func() {
+	//	It("returns SubscriptionCannotConnectToPrivateLink error", func(ctx context.Context) {
+	//		err = service.Reconcile(ctx)
+	//		Expect(err).To(HaveOccurred())
+	//		Expect(errors.IsPrivateLinksNotReady(err)).To(BeTrue())
+	//	})
+	//})
 })

--- a/pkg/privatelinks/scope.go
+++ b/pkg/privatelinks/scope.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	azurePrivateEndpointOperatorApiServerAnnotation string = "azure-private-endpoint-operator.giantswarm.io/private-link-apiserver-ip"
+	AzurePrivateEndpointOperatorApiServerAnnotation string = "azure-private-endpoint-operator.giantswarm.io/private-link-apiserver-ip"
 )
 
 func NewScope(workloadCluster *capz.AzureCluster, client client.Client) (*Scope, error) {
@@ -75,5 +75,5 @@ func (s *Scope) PrivateLinksReady() bool {
 }
 
 func (s *Scope) SetPrivateEndpointIPAddress(ip net.IP) {
-	s.BaseScope.SetAnnotation(azurePrivateEndpointOperatorApiServerAnnotation, ip.String())
+	s.BaseScope.SetAnnotation(AzurePrivateEndpointOperatorApiServerAnnotation, ip.String())
 }

--- a/pkg/testhelpers/azurecluster.go
+++ b/pkg/testhelpers/azurecluster.go
@@ -53,7 +53,7 @@ func (b *AzureClusterBuilder) WithCondition(condition *capi.Condition) *AzureClu
 func (b *AzureClusterBuilder) Build() *capz.AzureCluster {
 	azureCluster := capz.AzureCluster{
 		ObjectMeta: meta.ObjectMeta{
-			Name:      "test-cluster",
+			Name:      b.resourceGroup,
 			Namespace: "org-giantswarm",
 		},
 		Spec: capz.AzureClusterSpec{

--- a/pkg/testhelpers/azurecluster.go
+++ b/pkg/testhelpers/azurecluster.go
@@ -8,6 +8,7 @@ import (
 
 type AzureClusterBuilder struct {
 	subscriptionID string
+	location       string
 	resourceGroup  string
 	subnets        capz.Subnets
 	privateLinks   []capz.PrivateLink
@@ -19,6 +20,11 @@ func NewAzureClusterBuilder(subscriptionID, resourceGroup string) *AzureClusterB
 		subscriptionID: subscriptionID,
 		resourceGroup:  resourceGroup,
 	}
+}
+
+func (b *AzureClusterBuilder) WithLocation(location string) *AzureClusterBuilder {
+	b.location = location
+	return b
 }
 
 func (b *AzureClusterBuilder) WithSubnet(name string, role capz.SubnetRole, privateEndpoints capz.PrivateEndpoints) *AzureClusterBuilder {
@@ -54,6 +60,7 @@ func (b *AzureClusterBuilder) Build() *capz.AzureCluster {
 			ResourceGroup: b.resourceGroup,
 			AzureClusterClassSpec: capz.AzureClusterClassSpec{
 				SubscriptionID: b.subscriptionID,
+				Location:       b.location,
 			},
 			NetworkSpec: capz.NetworkSpec{
 				APIServerLB: capz.LoadBalancerSpec{

--- a/pkg/testhelpers/privateendpoint.go
+++ b/pkg/testhelpers/privateendpoint.go
@@ -8,6 +8,7 @@ import (
 
 type PrivateEndpointBuilder struct {
 	name                          string
+	location                      string
 	privateLinkServiceConnections []capz.PrivateLinkServiceConnection
 }
 
@@ -15,6 +16,11 @@ func NewPrivateEndpointBuilder(name string) *PrivateEndpointBuilder {
 	return &PrivateEndpointBuilder{
 		name: name,
 	}
+}
+
+func (b *PrivateEndpointBuilder) WithLocation(location string) *PrivateEndpointBuilder {
+	b.location = location
+	return b
 }
 
 func (b *PrivateEndpointBuilder) WithPrivateLinkServiceConnection(subscriptionID, resourceGroup, privateLinkName string) *PrivateEndpointBuilder {
@@ -32,6 +38,7 @@ func (b *PrivateEndpointBuilder) WithPrivateLinkServiceConnection(subscriptionID
 func (b *PrivateEndpointBuilder) Build() capz.PrivateEndpointSpec {
 	privateEndpoint := capz.PrivateEndpointSpec{
 		Name:                          b.name,
+		Location:                      b.location,
 		PrivateLinkServiceConnections: b.privateLinkServiceConnections,
 	}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2403

Note: This PR is the part of breaking up https://github.com/giantswarm/azure-private-endpoint-operator/pull/1 into smaller PRs that are easier to review.

This pull request is adding private endpoints `Service` that is providing reconciler functionality with `Reconcile(context.Context)` and `Delete(context.Context)` functions which are called from controller when the workload cluster is reconciled (due to a change or periodically) or deleted.