### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-
 ## [Unreleased]
+
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
 
 ## [0.1.0] - 2023-07-21
 

--- a/helm/azure-private-endpoint-operator/values.yaml
+++ b/helm/azure-private-endpoint-operator/values.yaml
@@ -6,7 +6,7 @@ project:
   commit: "[[ .SHA ]]"
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   name: giantswarm/azure-private-endpoint-operator
   tag: "[[ .Version ]]"
   pullPolicy: IfNotPresent
@@ -29,7 +29,7 @@ securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop:
-    - ALL
+      - ALL
 
 managementCluster:
   name: PLACEHOLDER


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
