### PR TITLE
Adjust deployment taints and node affinity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
+- Add node affinity to prefer schedule to `control-plane` nodes.
+
 ## [0.2.0] - 2024-03-21
 
 ### Added

--- a/helm/azure-private-endpoint-operator/templates/deployment.yaml
+++ b/helm/azure-private-endpoint-operator/templates/deployment.yaml
@@ -17,6 +17,14 @@ spec:
       labels:
         {{- include "labels.selector" . | nindent 8 }}
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            weight: 10
       serviceAccountName: {{ include "resource.default.name"  . }}
       securityContext:
         runAsNonRoot: true
@@ -75,3 +83,9 @@ spec:
             cpu: 200m
             memory: 128Mi
       terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: "node.cluster.x-k8s.io/uninitialized"
+        operator: "Exists"


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/30433

### Added

- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
- Add node affinity to prefer schedule to `control-plane` nodes.

