### PR TITLE
Allow to get and list "secrets"

### DIFF
--- a/helm/azure-private-endpoint-operator/templates/rbac.yaml
+++ b/helm/azure-private-endpoint-operator/templates/rbac.yaml
@@ -44,6 +44,16 @@ rules:
   - create
   - patch
 #
+# Secrets: Necessary when AzureClusterIdentity's type is ManualServicePrincipal
+#
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - patch
+#
 # AzureClusterIdentity
 #
 - apiGroups:


### PR DESCRIPTION
When the type of AzureClusterIdentity (referred by the AzureCluster) is "ManualServicePrincipal", the operator needs to list and get secrets in order to fetch the credentials.