### PR TITLE
Add --ingress-privateendpoint-enabled flag to control ingress PE creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `--ingress-privateendpoint-enabled` flag (bool, default `true`) to enable/disable creation of the ingress private endpoint (`<wc>-to-<mc>-privatelink-privateendpoint`) in workload clusters.
+- Expose `operator.ingressPrivateEndpointEnabled` Helm value (default `true`) to configure the flag.
+
 ## [0.4.0] - 2026-04-24
 
 ### Added

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -43,7 +43,8 @@ const (
 
 // Options holds optional configuration for AzureClusterReconciler.
 type Options struct {
-	McIngressIPSource string
+	McIngressIPSource              string
+	IngressPrivateEndpointEnabled  bool
 }
 
 // AzureClusterReconciler reconciles a AzureCluster object
@@ -189,7 +190,7 @@ func (r *AzureClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		//   a private link for the gateway (<mc-name>-gateway-privatelink).
 		// We add private endpoints to WC so that monitoring tools in WC can access MC ingress and gateway.
 		if err == nil && managementAzureCluster.Spec.NetworkSpec.APIServerLB.Type == capz.Internal {
-			err = wcPrivateEndpointsService.ReconcileWcToMcIngress(ctx, generateWcToMcPrivateEndpointSpecs(workloadAzureCluster, managementAzureCluster))
+			err = wcPrivateEndpointsService.ReconcileWcToMcIngress(ctx, generateWcToMcPrivateEndpointSpecs(workloadAzureCluster, managementAzureCluster, r.options.IngressPrivateEndpointEnabled))
 		}
 
 		if errors.IsRetriable(err) {
@@ -219,23 +220,28 @@ func (r *AzureClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 // generateWcToMcPrivateEndpointSpecs generates PrivateEndpointSpecs for the private endpoints that
 // connect the WC to the ingress and gateway of the management cluster.
 // It assumes private links named "<mc-name>-ingress-privatelink" and "<mc-name>-gateway-privatelink".
-func generateWcToMcPrivateEndpointSpecs(wc capz.AzureCluster, mc capz.AzureCluster) []capz.PrivateEndpointSpec {
-	ingressSpec := capz.PrivateEndpointSpec{
-		Name:     fmt.Sprintf("%s-to-%s-privatelink-privateendpoint", wc.Name, mc.Name),
-		Location: wc.Spec.Location,
-		PrivateLinkServiceConnections: []capz.PrivateLinkServiceConnection{
-			{
-				Name: fmt.Sprintf("%s-to-%s-connection", wc.Name, mc.Name),
-				PrivateLinkServiceID: fmt.Sprintf(
-					"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateLinkServices/%s",
-					mc.Spec.SubscriptionID,
-					mc.Name,
-					fmt.Sprintf("%s-ingress-privatelink", mc.Name)),
+func generateWcToMcPrivateEndpointSpecs(wc capz.AzureCluster, mc capz.AzureCluster, ingressPrivateEndpointEnabled bool) []capz.PrivateEndpointSpec {
+	var specs []capz.PrivateEndpointSpec
+
+	if ingressPrivateEndpointEnabled {
+		specs = append(specs, capz.PrivateEndpointSpec{
+			Name:     fmt.Sprintf("%s-to-%s-privatelink-privateendpoint", wc.Name, mc.Name),
+			Location: wc.Spec.Location,
+			PrivateLinkServiceConnections: []capz.PrivateLinkServiceConnection{
+				{
+					Name: fmt.Sprintf("%s-to-%s-connection", wc.Name, mc.Name),
+					PrivateLinkServiceID: fmt.Sprintf(
+						"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateLinkServices/%s",
+						mc.Spec.SubscriptionID,
+						mc.Name,
+						fmt.Sprintf("%s-ingress-privatelink", mc.Name)),
+				},
 			},
-		},
-		ManualApproval: false,
+			ManualApproval: false,
+		})
 	}
-	gatewaySpec := capz.PrivateEndpointSpec{
+
+	specs = append(specs, capz.PrivateEndpointSpec{
 		Name:     fmt.Sprintf("%s-to-%s-gateway-privateendpoint", wc.Name, mc.Name),
 		Location: wc.Spec.Location,
 		PrivateLinkServiceConnections: []capz.PrivateLinkServiceConnection{
@@ -249,8 +255,9 @@ func generateWcToMcPrivateEndpointSpecs(wc capz.AzureCluster, mc capz.AzureClust
 			},
 		},
 		ManualApproval: false,
-	}
-	return []capz.PrivateEndpointSpec{ingressSpec, gatewaySpec}
+	})
+
+	return specs
 }
 
 // validateLBType checks if the load balancer type is either Internal or Public. Any

--- a/controllers/azurecluster_controller_test.go
+++ b/controllers/azurecluster_controller_test.go
@@ -401,7 +401,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 
 		JustBeforeEach(func() {
 			var err error
-			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway, IngressPrivateEndpointEnabled: true})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -530,7 +530,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 
 		JustBeforeEach(func() {
 			var err error
-			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway, IngressPrivateEndpointEnabled: true})
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/helm/azure-private-endpoint-operator/templates/deployment.yaml
+++ b/helm/azure-private-endpoint-operator/templates/deployment.yaml
@@ -49,6 +49,7 @@ spec:
         - -management-cluster-name={{ .Values.managementCluster.name }}
         - -management-cluster-namespace={{ .Values.managementCluster.namespace }}
         - --mc-ingress-ip-source={{ .Values.operator.mcIngressIPSource }}
+        - --ingress-privateendpoint-enabled={{ .Values.operator.ingressPrivateEndpointEnabled }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/helm/azure-private-endpoint-operator/values.yaml
+++ b/helm/azure-private-endpoint-operator/values.yaml
@@ -38,3 +38,4 @@ azure:
 
 operator:
   mcIngressIPSource: "ingress"
+  ingressPrivateEndpointEnabled: true

--- a/main.go
+++ b/main.go
@@ -56,13 +56,14 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr                string
-		enableLeaderElection       bool
-		probeAddr                  string
-		managementClusterName      string
-		managementClusterNamespace string
-		syncPeriod                 time.Duration
-		mcIngressIPSource          string
+		metricsAddr                        string
+		enableLeaderElection               bool
+		probeAddr                          string
+		managementClusterName              string
+		managementClusterNamespace         string
+		syncPeriod                         time.Duration
+		mcIngressIPSource                  string
+		ingressPrivateEndpointEnabled      bool
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080",
 		"The address the metric endpoint binds to.")
@@ -79,6 +80,8 @@ func main() {
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 	flag.StringVar(&mcIngressIPSource, "mc-ingress-ip-source", "ingress",
 		"Source private endpoint for the MC ingress IP annotation (ingress or gateway)")
+	flag.BoolVar(&ingressPrivateEndpointEnabled, "ingress-privateendpoint-enabled", true,
+		"Enable creation of the private endpoint for the MC ingress private link in workload clusters")
 	opts := zap.Options{
 		Development: false,
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
@@ -124,7 +127,8 @@ func main() {
 		Name:      managementClusterName,
 	}
 	azureClusterReconciler, err := controllers.NewAzureClusterReconciler(mgr.GetClient(), azure.NewPrivateEndpointClient, mcNamespacedName, controllers.Options{
-		McIngressIPSource: mcIngressIPSource,
+		McIngressIPSource:             mcIngressIPSource,
+		IngressPrivateEndpointEnabled: ingressPrivateEndpointEnabled,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to create new AzureClusterReconciler")


### PR DESCRIPTION
Add a new boolean flag (default true) to enable or disable creation of
the ingress private endpoint in workload clusters, allowing operators to
skip the MC ingress privatelink PE when it is not needed.
