### PR TITLE
Remove ingress privatelink private endpoint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
+### Breaking changes
 
-- **Breaking change:** Remove ingress private endpoint (`<wc>-to-<mc>-privatelink-privateendpoint`). Only the gateway private endpoint (`<wc>-to-<mc>-gateway-privateendpoint`) is now created. Clusters relying on the ingress private endpoint must migrate to the gateway-based setup before upgrading.
-- **Breaking change:** Remove `--mc-ingress-ip-source` flag. The gateway private endpoint IP is now always written to the `azure-private-endpoint-operator.giantswarm.io/private-link-mc-ingress-ip` annotation.
-- **Breaking change:** Remove `operator.mcIngressIPSource` Helm value.
+- Remove ingress private endpoint (`<wc>-to-<mc>-privatelink-privateendpoint`). Only the gateway private endpoint (`<wc>-to-<mc>-gateway-privateendpoint`) is now created.
+- Remove `--mc-ingress-ip-source` flag. The gateway private endpoint IP is now always written to the `azure-private-endpoint-operator.giantswarm.io/private-link-mc-ingress-ip` annotation.
+- Remove `operator.mcIngressIPSource` Helm value.
 
 ## [0.4.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove ingress private endpoint (`<wc>-to-<mc>-privatelink-privateendpoint`) and the `--mc-ingress-ip-source` flag; only the gateway private endpoint is now created, and its IP is always written to the `azure-private-endpoint-operator.giantswarm.io/private-link-mc-ingress-ip` annotation.
+
 ## [0.4.0] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Remove ingress private endpoint (`<wc>-to-<mc>-privatelink-privateendpoint`) and the `--mc-ingress-ip-source` flag; only the gateway private endpoint is now created, and its IP is always written to the `azure-private-endpoint-operator.giantswarm.io/private-link-mc-ingress-ip` annotation.
+- **Breaking change:** Remove ingress private endpoint (`<wc>-to-<mc>-privatelink-privateendpoint`). Only the gateway private endpoint (`<wc>-to-<mc>-gateway-privateendpoint`) is now created. Clusters relying on the ingress private endpoint must migrate to the gateway-based setup before upgrading.
+- **Breaking change:** Remove `--mc-ingress-ip-source` flag. The gateway private endpoint IP is now always written to the `azure-private-endpoint-operator.giantswarm.io/private-link-mc-ingress-ip` annotation.
+- **Breaking change:** Remove `operator.mcIngressIPSource` Helm value.
 
 ## [0.4.0] - 2026-04-24
 

--- a/controllers/azurecluster_controller.go
+++ b/controllers/azurecluster_controller.go
@@ -42,9 +42,7 @@ const (
 )
 
 // Options holds optional configuration for AzureClusterReconciler.
-type Options struct {
-	McIngressIPSource string
-}
+type Options struct{}
 
 // AzureClusterReconciler reconciles a AzureCluster object
 type AzureClusterReconciler struct {
@@ -67,10 +65,6 @@ func NewAzureClusterReconciler(client client.Client, privateEndpointsClientCreat
 	if managementClusterName.Namespace == "" {
 		return nil, microerror.Maskf(errors.InvalidConfigError, "%T.Namespace must be set", managementClusterName)
 	}
-	if options.McIngressIPSource != privateendpoints.McIngressIPSourceIngress && options.McIngressIPSource != privateendpoints.McIngressIPSourceGateway {
-		return nil, microerror.Maskf(errors.InvalidConfigError, "options.McIngressIPSource must be %q or %q, got %q", privateendpoints.McIngressIPSourceIngress, privateendpoints.McIngressIPSourceGateway, options.McIngressIPSource)
-	}
-
 	return &AzureClusterReconciler{
 		Client:                        client,
 		privateEndpointsClientCreator: privateEndpointsClientCreator,
@@ -124,7 +118,7 @@ func (r *AzureClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Create WC private links scope - we use this to get the info about the private workload
 	// cluster private links, and then we make sure to have a private endpoints that connect to the
 	// private links.
-	privateLinksScope, err := privatelinks.NewScope(&workloadAzureCluster, r.Client, r.options.McIngressIPSource)
+	privateLinksScope, err := privatelinks.NewScope(&workloadAzureCluster, r.Client)
 	if err != nil {
 		return ctrl.Result{}, microerror.Mask(err)
 	}
@@ -183,11 +177,9 @@ func (r *AzureClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			err = mcPrivateEndpointsService.ReconcileMcToWcApi(ctx)
 		}
 
-		// When LB of k8s api of MC is internal load balancer, we assume
-		// - The cluster is private and both ingress and gateway LBs are internal.
-		// - There is a private link for the ingress LB (<mc-name>-ingress-privatelink) and
-		//   a private link for the gateway (<mc-name>-gateway-privatelink).
-		// We add private endpoints to WC so that monitoring tools in WC can access MC ingress and gateway.
+		// When LB of k8s api of MC is internal load balancer, we assume the cluster is private
+		// and the gateway LB is internal with a private link (<mc-name>-gateway-privatelink).
+		// We add a private endpoint to WC so that monitoring tools in WC can access the MC gateway.
 		if err == nil && managementAzureCluster.Spec.NetworkSpec.APIServerLB.Type == capz.Internal {
 			err = wcPrivateEndpointsService.ReconcileWcToMcIngress(ctx, generateWcToMcPrivateEndpointSpecs(workloadAzureCluster, managementAzureCluster))
 		}
@@ -216,25 +208,10 @@ func (r *AzureClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	return ctrl.Result{}, nil
 }
 
-// generateWcToMcPrivateEndpointSpecs generates PrivateEndpointSpecs for the private endpoints that
-// connect the WC to the ingress and gateway of the management cluster.
-// It assumes private links named "<mc-name>-ingress-privatelink" and "<mc-name>-gateway-privatelink".
+// generateWcToMcPrivateEndpointSpecs generates PrivateEndpointSpecs for the private endpoint that
+// connects the WC to the gateway of the management cluster.
+// It assumes a private link named "<mc-name>-gateway-privatelink".
 func generateWcToMcPrivateEndpointSpecs(wc capz.AzureCluster, mc capz.AzureCluster) []capz.PrivateEndpointSpec {
-	ingressSpec := capz.PrivateEndpointSpec{
-		Name:     fmt.Sprintf("%s-to-%s-privatelink-privateendpoint", wc.Name, mc.Name),
-		Location: wc.Spec.Location,
-		PrivateLinkServiceConnections: []capz.PrivateLinkServiceConnection{
-			{
-				Name: fmt.Sprintf("%s-to-%s-connection", wc.Name, mc.Name),
-				PrivateLinkServiceID: fmt.Sprintf(
-					"/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/privateLinkServices/%s",
-					mc.Spec.SubscriptionID,
-					mc.Name,
-					fmt.Sprintf("%s-ingress-privatelink", mc.Name)),
-			},
-		},
-		ManualApproval: false,
-	}
 	gatewaySpec := capz.PrivateEndpointSpec{
 		Name:     fmt.Sprintf("%s-to-%s-gateway-privateendpoint", wc.Name, mc.Name),
 		Location: wc.Spec.Location,
@@ -250,7 +227,7 @@ func generateWcToMcPrivateEndpointSpecs(wc capz.AzureCluster, mc capz.AzureClust
 		},
 		ManualApproval: false,
 	}
-	return []capz.PrivateEndpointSpec{ingressSpec, gatewaySpec}
+	return []capz.PrivateEndpointSpec{gatewaySpec}
 }
 
 // validateLBType checks if the load balancer type is either Internal or Public. Any

--- a/controllers/azurecluster_controller_test.go
+++ b/controllers/azurecluster_controller_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/azure"
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/azure/mock_azure"
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/errors"
-	"github.com/giantswarm/azure-private-endpoint-operator/pkg/privateendpoints"
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/privatelinks"
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/testhelpers"
 )
@@ -28,8 +27,6 @@ import (
 const (
 	testPrivateLinkNameForWcAPI       = "super-private-link"
 	testPrivateEndpointIpForWcAPI     = "10.10.10.10"
-	testPrivateLinkNameForMcIngress   = "giant-ingress-privatelink"
-	testPrivateEndpointIpForMcIngress = "10.10.10.11"
 	testPrivateLinkNameForMcGateway   = "giant-gateway-privatelink"
 	testPrivateEndpointIpForMcGateway = "10.10.10.12"
 )
@@ -98,21 +95,21 @@ var _ = Describe("AzureClusterReconciler", func() {
 	Describe("creating reconciler", func() {
 		It("creates reconciler", func(ctx context.Context) {
 			var err error
-			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(reconciler).NotTo(BeNil())
 		})
 
 		It("fails to create reconciler when client is nil", func(ctx context.Context) {
 			var err error
-			_, err = controllers.NewAzureClusterReconciler(nil, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+			_, err = controllers.NewAzureClusterReconciler(nil, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{})
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsInvalidConfig(err)).To(BeTrue())
 		})
 
 		It("fails to create reconciler when private endpoints creator is nil", func(ctx context.Context) {
 			var err error
-			_, err = controllers.NewAzureClusterReconciler(k8sClient, nil, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+			_, err = controllers.NewAzureClusterReconciler(k8sClient, nil, managementClusterNamespacedName, controllers.Options{})
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsInvalidConfig(err)).To(BeTrue())
 		})
@@ -120,7 +117,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 		It("fails to create reconciler when MC name is empty", func(ctx context.Context) {
 			var err error
 			managementClusterNamespacedName.Name = ""
-			_, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+			_, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{})
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsInvalidConfig(err)).To(BeTrue())
 		})
@@ -128,7 +125,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 		It("fails to create reconciler when MC namespace is empty", func(ctx context.Context) {
 			var err error
 			managementClusterNamespacedName.Namespace = ""
-			_, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+			_, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{})
 			Expect(err).To(HaveOccurred())
 			Expect(errors.IsInvalidConfig(err)).To(BeTrue())
 		})
@@ -138,7 +135,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 		When("workload AzureCluster resources does not exist", func() {
 			JustBeforeEach(func() {
 				var err error
-				reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+				reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{})
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -164,7 +161,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 
 			JustBeforeEach(func() {
 				var err error
-				reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+				reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{})
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -194,7 +191,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 
 			JustBeforeEach(func() {
 				var err error
-				reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+				reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{})
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -220,7 +217,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 
 			JustBeforeEach(func() {
 				var err error
-				reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+				reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{})
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -280,7 +277,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 
 		JustBeforeEach(func() {
 			var err error
-			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -389,11 +386,6 @@ var _ = Describe("AzureClusterReconciler", func() {
 					testhelpers.SetupPrivateEndpointClientToReturnPrivateIp(
 						privateEndpointsClient,
 						workloadClusterName,
-						fmt.Sprintf("%s-to-%s-privatelink-privateendpoint", workloadClusterName, managementClusterName),
-						testPrivateEndpointIpForMcIngress)
-					testhelpers.SetupPrivateEndpointClientToReturnPrivateIp(
-						privateEndpointsClient,
-						workloadClusterName,
 						fmt.Sprintf("%s-to-%s-gateway-privateendpoint", workloadClusterName, managementClusterName),
 						testPrivateEndpointIpForMcGateway)
 				}
@@ -403,7 +395,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 
 		JustBeforeEach(func() {
 			var err error
-			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -447,27 +439,20 @@ var _ = Describe("AzureClusterReconciler", func() {
 			Expect(ok).To(BeTrue())
 			Expect(privateEndpointIpForMcIngress).To(Equal(testPrivateEndpointIpForMcGateway))
 
-			// done: both private endpoints have been added to the WC
-			expectedIngressPrivateEndpointInWc := testhelpers.NewPrivateEndpointBuilder(fmt.Sprintf("%s-to-%s-privatelink-privateendpoint", workloadClusterName, managementClusterName)).
-				WithLocation(location).
-				WithPrivateLinkServiceConnectionWithName(subscriptionID, managementClusterName, testPrivateLinkNameForMcIngress,
-					fmt.Sprintf("%s-to-%s-connection", workloadClusterName, managementClusterName)).
-				Build()
+			// done: gateway private endpoint has been added to the WC
 			expectedGatewayPrivateEndpointInWc := testhelpers.NewPrivateEndpointBuilder(fmt.Sprintf("%s-to-%s-gateway-privateendpoint", workloadClusterName, managementClusterName)).
 				WithLocation(location).
 				WithPrivateLinkServiceConnectionWithName(subscriptionID, managementClusterName, testPrivateLinkNameForMcGateway,
 					fmt.Sprintf("%s-to-%s-gateway-connection", workloadClusterName, managementClusterName)).
 				Build()
-			Expect(workloadAzureCluster.Spec.NetworkSpec.Subnets[0].PrivateEndpoints).To(HaveLen(2))
+			Expect(workloadAzureCluster.Spec.NetworkSpec.Subnets[0].PrivateEndpoints).To(HaveLen(1))
 
 			// done: status condition has been added to the WC
 			Expect(workloadAzureCluster.GetConditions()).To(testhelpers.MeetConditions(privateendpoints.ConditionGSPrivateLinksReady))
 
 			// normalize resources before comparison (we don't care about this field here)
 			workloadAzureCluster.Spec.NetworkSpec.Subnets[0].PrivateEndpoints[0].PrivateLinkServiceConnections[0].RequestMessage = ""
-			workloadAzureCluster.Spec.NetworkSpec.Subnets[0].PrivateEndpoints[1].PrivateLinkServiceConnections[0].RequestMessage = ""
-			Expect(workloadAzureCluster.Spec.NetworkSpec.Subnets[0].PrivateEndpoints[0]).To(Equal(expectedIngressPrivateEndpointInWc))
-			Expect(workloadAzureCluster.Spec.NetworkSpec.Subnets[0].PrivateEndpoints[1]).To(Equal(expectedGatewayPrivateEndpointInWc))
+			Expect(workloadAzureCluster.Spec.NetworkSpec.Subnets[0].PrivateEndpoints[0]).To(Equal(expectedGatewayPrivateEndpointInWc))
 		})
 	})
 
@@ -501,7 +486,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 
 		JustBeforeEach(func() {
 			var err error
-			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -535,7 +520,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 
 		JustBeforeEach(func() {
 			var err error
-			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{McIngressIPSource: privateendpoints.McIngressIPSourceGateway})
+			reconciler, err = controllers.NewAzureClusterReconciler(k8sClient, privateEndpointsClientCreator, managementClusterNamespacedName, controllers.Options{})
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -632,7 +617,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 					gomockController := gomock.NewController(GinkgoT())
 					privateEndpointsClient := mock_azure.NewMockPrivateEndpointsClient(gomockController)
 					if cluster.Name == workloadClusterName {
-						expectedPrivateEndpointName := fmt.Sprintf("%s-to-%s-privatelink-privateendpoint", workloadClusterName, managementClusterName)
+						expectedPrivateEndpointName := fmt.Sprintf("%s-to-%s-gateway-privateendpoint", workloadClusterName, managementClusterName)
 						testhelpers.SetupPrivateEndpointClientToReturnNotFound(
 							privateEndpointsClient,
 							workloadClusterName,
@@ -716,7 +701,7 @@ var _ = Describe("AzureClusterReconciler", func() {
 					gomockController := gomock.NewController(GinkgoT())
 					privateEndpointsClient := mock_azure.NewMockPrivateEndpointsClient(gomockController)
 					if cluster.Name == workloadClusterName {
-						expectedPrivateEndpointName := fmt.Sprintf("%s-to-%s-privatelink-privateendpoint", workloadClusterName, managementClusterName)
+						expectedPrivateEndpointName := fmt.Sprintf("%s-to-%s-gateway-privateendpoint", workloadClusterName, managementClusterName)
 						testhelpers.SetupPrivateEndpointClientWithoutPrivateIp(
 							privateEndpointsClient,
 							workloadClusterName,

--- a/controllers/azurecluster_controller_test.go
+++ b/controllers/azurecluster_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/azure"
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/azure/mock_azure"
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/errors"
+	"github.com/giantswarm/azure-private-endpoint-operator/pkg/privateendpoints"
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/privatelinks"
 	"github.com/giantswarm/azure-private-endpoint-operator/pkg/testhelpers"
 )

--- a/helm/azure-private-endpoint-operator/templates/deployment.yaml
+++ b/helm/azure-private-endpoint-operator/templates/deployment.yaml
@@ -51,7 +51,6 @@ spec:
         {{- with .Values.azureClusterGates }}
         - -azure-cluster-gates={{ join "," . }}
         {{- end }}
-        - --mc-ingress-ip-source={{ .Values.operator.mcIngressIPSource }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/helm/azure-private-endpoint-operator/values.schema.json
+++ b/helm/azure-private-endpoint-operator/values.schema.json
@@ -108,15 +108,6 @@
                 }
             }
         },
-        "operator": {
-            "type": "object",
-            "properties": {
-                "mcIngressIPSource": {
-                    "type": "string",
-                    "enum": ["ingress", "gateway"]
-                }
-            }
-        },
         "serviceType": {
             "type": "string"
         }

--- a/helm/azure-private-endpoint-operator/values.yaml
+++ b/helm/azure-private-endpoint-operator/values.yaml
@@ -35,6 +35,3 @@ managementCluster:
 azure:
   workloadIdentity:
     clientID: ""
-
-operator:
-  mcIngressIPSource: "ingress"

--- a/main.go
+++ b/main.go
@@ -65,7 +65,6 @@ func main() {
 		managementClusterNamespace string
 		azureClusterGates          ConditionSliceVar
 		syncPeriod                 time.Duration
-		mcIngressIPSource          string
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080",
 		"The address the metric endpoint binds to.")
@@ -82,8 +81,6 @@ func main() {
 		"Status conditions on the workload AzureCluster CR that must be true before the control plane starts reconciling")
 	flag.DurationVar(&syncPeriod, "sync-period", 5*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
-	flag.StringVar(&mcIngressIPSource, "mc-ingress-ip-source", "ingress",
-		"Source private endpoint for the MC ingress IP annotation (ingress or gateway)")
 	opts := zap.Options{
 		Development: false,
 		TimeEncoder: zapcore.ISO8601TimeEncoder,
@@ -128,9 +125,7 @@ func main() {
 		Namespace: managementClusterNamespace,
 		Name:      managementClusterName,
 	}
-	azureClusterReconciler, err := controllers.NewAzureClusterReconciler(mgr.GetClient(), azure.NewPrivateEndpointClient, mcNamespacedName, controllers.Options{
-		McIngressIPSource: mcIngressIPSource,
-	})
+	azureClusterReconciler, err := controllers.NewAzureClusterReconciler(mgr.GetClient(), azure.NewPrivateEndpointClient, mcNamespacedName, controllers.Options{})
 	if err != nil {
 		setupLog.Error(err, "unable to create new AzureClusterReconciler")
 		os.Exit(1)

--- a/pkg/privateendpoints/service.go
+++ b/pkg/privateendpoints/service.go
@@ -20,9 +20,6 @@ import (
 
 const (
 	ConditionGSPrivateLinksReady capi.ConditionType = "GSPrivateLinksReady"
-
-	McIngressIPSourceIngress = "ingress"
-	McIngressIPSourceGateway = "gateway"
 )
 
 // PrivateLinksScope is the interface for getting private links for which the private endpoints are needed.
@@ -35,7 +32,6 @@ type PrivateLinksScope interface {
 	LookupPrivateLink(privateLinkResourceID string) (capz.PrivateLink, bool)
 	PatchObject(ctx context.Context) error
 	PrivateLinksReady() bool
-	IsMcIngressEndpoint(name string) bool
 	SetPrivateEndpointIPAddressForWcApi(ip net.IP)
 	SetPrivateEndpointIPAddressForMcIngress(ip net.IP)
 	SetCondition(condition capi.Condition)
@@ -169,11 +165,8 @@ func (s *Service) ReconcileWcToMcIngress(ctx context.Context, specs []capz.Priva
 			return microerror.Mask(err)
 		}
 		logger.Info("found private endpoint IP address in WC", "name", spec.Name, "ipAddress", ip.String())
-
-		if s.privateLinksScope.IsMcIngressEndpoint(spec.Name) {
-			s.privateLinksScope.SetPrivateEndpointIPAddressForMcIngress(ip)
-			logger.Info("set private endpoint IP address in WC AzureCluster", "name", spec.Name, "ipAddress", ip.String())
-		}
+		s.privateLinksScope.SetPrivateEndpointIPAddressForMcIngress(ip)
+		logger.Info("set private endpoint IP address in WC AzureCluster", "name", spec.Name, "ipAddress", ip.String())
 	}
 
 	s.privateLinksScope.SetCondition(capi.Condition{

--- a/pkg/privateendpoints/service_test.go
+++ b/pkg/privateendpoints/service_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Service", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Private links scope
-			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client, "")
+			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Private endpoints service
@@ -124,7 +124,7 @@ var _ = Describe("Service", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Private links scope
-			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client, "")
+			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Private endpoints service
@@ -176,7 +176,7 @@ var _ = Describe("Service", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Private links scope
-			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client, "")
+			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Private endpoints service
@@ -283,7 +283,7 @@ var _ = Describe("Service", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Private links scope
-			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client, "")
+			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Private endpoints service
@@ -360,7 +360,7 @@ var _ = Describe("Service", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Private links scope
-			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client, "")
+			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Private endpoints service
@@ -432,7 +432,7 @@ var _ = Describe("Service", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Private links scope
-			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client, "")
+			privateLinksScope, err = privatelinks.NewScope(workloadAzureCluster, client)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Private endpoints service

--- a/pkg/privatelinks/scope.go
+++ b/pkg/privatelinks/scope.go
@@ -19,7 +19,6 @@ const (
 	AzurePrivateEndpointOperatorMcIngressAnnotation string = "azure-private-endpoint-operator.giantswarm.io/private-link-mc-ingress-ip"
 )
 
-
 func NewScope(workloadCluster *capz.AzureCluster, client client.Client) (*Scope, error) {
 	if workloadCluster == nil {
 		return nil, microerror.Maskf(errors.InvalidConfigError, "workloadCluster must be set")

--- a/pkg/privatelinks/scope.go
+++ b/pkg/privatelinks/scope.go
@@ -3,7 +3,6 @@ package privatelinks
 import (
 	"fmt"
 	"net"
-	"regexp"
 
 	capz "sigs.k8s.io/cluster-api-provider-azure/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,12 +19,8 @@ const (
 	AzurePrivateEndpointOperatorMcIngressAnnotation string = "azure-private-endpoint-operator.giantswarm.io/private-link-mc-ingress-ip"
 )
 
-var (
-	ingressEndpointRegex = regexp.MustCompile(`-privatelink-privateendpoint$`)
-	gatewayEndpointRegex = regexp.MustCompile(`-gateway-privateendpoint$`)
-)
 
-func NewScope(workloadCluster *capz.AzureCluster, client client.Client, mcIngressIPSource string) (*Scope, error) {
+func NewScope(workloadCluster *capz.AzureCluster, client client.Client) (*Scope, error) {
 	if workloadCluster == nil {
 		return nil, microerror.Maskf(errors.InvalidConfigError, "workloadCluster must be set")
 	}
@@ -39,9 +34,8 @@ func NewScope(workloadCluster *capz.AzureCluster, client client.Client, mcIngres
 	}
 
 	scope := Scope{
-		BaseScope:         *baseScope,
-		privateLinks:      workloadCluster.Spec.NetworkSpec.APIServerLB.PrivateLinks,
-		mcIngressIPSource: mcIngressIPSource,
+		BaseScope:    *baseScope,
+		privateLinks: workloadCluster.Spec.NetworkSpec.APIServerLB.PrivateLinks,
 	}
 
 	return &scope, nil
@@ -49,8 +43,7 @@ func NewScope(workloadCluster *capz.AzureCluster, client client.Client, mcIngres
 
 type Scope struct {
 	azurecluster.BaseScope
-	privateLinks      []capz.PrivateLink
-	mcIngressIPSource string
+	privateLinks []capz.PrivateLink
 }
 
 func (s *Scope) LookupPrivateLink(privateLinkResourceID string) (capz.PrivateLink, bool) {
@@ -81,18 +74,6 @@ func (s *Scope) GetPrivateLinksWithAllowedSubscription(managementClusterSubscrip
 
 func (s *Scope) PrivateLinksReady() bool {
 	return s.IsConditionTrue(capz.PrivateLinksReadyCondition)
-}
-
-// IsMcIngressEndpoint returns true if the given endpoint name matches the pattern
-// for the configured MC ingress IP source (ingress or gateway).
-func (s *Scope) IsMcIngressEndpoint(name string) bool {
-	switch s.mcIngressIPSource {
-	case "ingress":
-		return ingressEndpointRegex.MatchString(name)
-	case "gateway":
-		return gatewayEndpointRegex.MatchString(name)
-	}
-	return false
 }
 
 func (s *Scope) SetPrivateEndpointIPAddressForWcApi(ip net.IP) {

--- a/pkg/privatelinks/scope_test.go
+++ b/pkg/privatelinks/scope_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Scope", func() {
 
 		When("AzureCluster is not set", func() {
 			It("returns an invalid config error", func() {
-				_, err := privatelinks.NewScope(nil, client, "")
+				_, err := privatelinks.NewScope(nil, client)
 				Expect(err).To(HaveOccurred())
 				Expect(errors.IsInvalidConfig(err)).To(BeTrue())
 			})
@@ -50,7 +50,7 @@ var _ = Describe("Scope", func() {
 
 		When("kubernetes client is not set", func() {
 			It("returns an invalid config error", func() {
-				_, err := privatelinks.NewScope(azureCluster, nil, "")
+				_, err := privatelinks.NewScope(azureCluster, nil)
 				Expect(err).To(HaveOccurred())
 				Expect(errors.IsInvalidConfig(err)).To(BeTrue())
 			})
@@ -58,7 +58,7 @@ var _ = Describe("Scope", func() {
 
 		When("both AzureCluster and client are set", func() {
 			It("creates the scope", func() {
-				_, err := privatelinks.NewScope(azureCluster, client, "")
+				_, err := privatelinks.NewScope(azureCluster, client)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
@@ -79,7 +79,7 @@ var _ = Describe("Scope", func() {
 			client := fake.NewClientBuilder().
 				WithScheme(capzSchema).
 				WithObjects(azureCluster).Build()
-			scope, err = privatelinks.NewScope(azureCluster, client, "")
+			scope, err = privatelinks.NewScope(azureCluster, client)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -157,7 +157,7 @@ var _ = Describe("Scope", func() {
 			client := fake.NewClientBuilder().
 				WithScheme(capzSchema).
 				WithObjects(azureCluster).Build()
-			scope, err = privatelinks.NewScope(azureCluster, client, "")
+			scope, err = privatelinks.NewScope(azureCluster, client)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -223,7 +223,7 @@ var _ = Describe("Scope", func() {
 			client := fake.NewClientBuilder().
 				WithScheme(capzSchema).
 				WithObjects(azureCluster).Build()
-			scope, err = privatelinks.NewScope(azureCluster, client, "")
+			scope, err = privatelinks.NewScope(azureCluster, client)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -279,7 +279,7 @@ var _ = Describe("Scope", func() {
 			client := fake.NewClientBuilder().
 				WithScheme(capzSchema).
 				WithObjects(azureCluster).Build()
-			scope, err = privatelinks.NewScope(azureCluster, client, "")
+			scope, err = privatelinks.NewScope(azureCluster, client)
 			Expect(err).NotTo(HaveOccurred())
 		})
 


### PR DESCRIPTION
Drop the ingress-privatelink private endpoint and the --mc-ingress-ip-source
flag. Only the gateway private endpoint remains, and its IP is always written
to the mc-ingress-ip annotation.
